### PR TITLE
speed improvement

### DIFF
--- a/raspledstrip/LPD8806.py
+++ b/raspledstrip/LPD8806.py
@@ -24,16 +24,13 @@ class LPD8806(object):
             self.spi.xfer2([0x00,0x00,0x00]) #zero fill the last to prevent stray colors at the end
             self.spi.xfer2([0x00]) #once more with feeling - this helps :)
         else:
+            spibuffer=str()
             for x in range(self.leds):
-                self.spi.write(buffer[x])
-                self.spi.flush()
+                spibuffer+=buffer[x]
+
+            self.spi.write(buffer[x])
+            self.spi.flush()
             #seems that the more lights we have the more you have to push zeros
             #not 100% sure why this is yet, but it seems to work
-            self.spi.write(bytearray(b'\x00\x00\x00')) #zero fill the last to prevent stray colors at the end
-            self.spi.flush()
-            self.spi.write(bytearray(b'\x00\x00\x00'))
-            self.spi.flush()
-            self.spi.write(bytearray(b'\x00\x00\x00'))
-            self.spi.flush()
-            self.spi.write(bytearray(b'\x00\x00\x00'))
+            self.spi.write(bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')) #zero fill the last to prevent stray colors at the end
             self.spi.flush()


### PR DESCRIPTION
I need one LED to travel along the strip as fast as possible. I have 5m strip with 260 LEDs (130 LPD8806 chips). When I first tried with code from adammhaile's repo the led.update() execution time took about 70ms on my raspberrypi configuration. With following code modification I first build the whole spibuffer in RAM using for loop. After for loop finishes its only one write and flush operation. With this improvement the led.update() execution time dropped to about 3ms which I find great. Please comment that.
